### PR TITLE
dynamically fetch the deno version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,6 @@ outputs:
 
 runs:
   using: node20
-  # pre: bootstrap/pre.cjs
-  main: bootstrap/main.cjs
-  # post: bootstrap/post.cjs
+  # pre: bootstrap/pre.mjs
+  main: bootstrap/main.mjs
+  # post: bootstrap/post.mjs

--- a/bootstrap/main.cjs
+++ b/bootstrap/main.cjs
@@ -1,1 +1,0 @@
-require("./run.cjs")(require.resolve("../main.ts"));

--- a/bootstrap/main.mjs
+++ b/bootstrap/main.mjs
@@ -1,0 +1,2 @@
+import run from "./run.mjs";
+run(import.meta.resolve("../main.ts"));

--- a/bootstrap/post.cjs
+++ b/bootstrap/post.cjs
@@ -1,1 +1,0 @@
-// require("./run.cjs")(require.resolve("../post.ts"));

--- a/bootstrap/post.mjs
+++ b/bootstrap/post.mjs
@@ -1,0 +1,2 @@
+// import run from "./run.mjs";
+// run(import.meta.resolve("../post.ts"));

--- a/bootstrap/pre.cjs
+++ b/bootstrap/pre.cjs
@@ -1,1 +1,0 @@
-// require("./run.cjs")(require.resolve("../pre.ts"));

--- a/bootstrap/pre.mjs
+++ b/bootstrap/pre.mjs
@@ -1,0 +1,2 @@
+// import run from "./run.mjs";
+// run(import.meta.resolve("../pre.ts"));

--- a/bootstrap/run.cjs
+++ b/bootstrap/run.cjs
@@ -17,6 +17,22 @@ if (!process.env.RUNNER_TOOL_CACHE || !process.env.RUNNER_TEMP) {
   throw new Error("This file must be run in a GitHub Actions environment.");
 }
 
+const ARCH = {
+  arm64: "aarch64",
+  x64: "x86_64",
+}[process.arch];
+const OS = {
+  win32: "pc-windows-msvc",
+  darwin: "apple-darwin",
+  linux: "unknown-linux-gnu",
+}[process.platform];
+
+if (!ARCH) throw new Error(`Unsupported architecture: ${process.arch}`);
+if (!OS) throw new Error(`Unsupported OS: ${process.platform}`);
+
+const URL =
+  `https://github.com/denoland/deno/releases/download/${DENO_VERSION}/deno-${ARCH}-${OS}.zip`;
+
 module.exports = (file) => {
   const child = spawnSync("bash", [
     "-c",
@@ -27,22 +43,9 @@ cache="$RUNNER_TOOL_CACHE/deno-action/${DENO_VERSION}/${process.arch}"
 mkdir -p "$cache"
 zip="$RUNNER_TEMP/deno-${DENO_VERSION}.zip"
 
-echo $(uname -sm) $RUNNER_OS
-
-case $RUNNER_OS-$(uname -m); in
-Windows-x86_64) target="x86_64-pc-windows-msvc" ;;
-Darwin-x86_64)  target="x86_64-apple-darwin" ;;
-Darwin-arm64)   target="aarch64-apple-darwin" ;;
-Linux-aarch64)  target="aarch64-unknown-linux-gnu" ;;
-Linux-x86_64)   target="x86_64-unknown-linux-gnu" ;;
-*) echo "Unsupported os/architecture"; exit 1 ;;
-esac
-
-url="https://github.com/denoland/deno/releases/download/${DENO_VERSION}/deno-\${target}.zip"
-
 if [ ! -f "$cache.complete" ]; then
   echo "Downloading Deno..."
-  curl --silent --fail --location "$url" --output "$zip"
+  curl --silent --fail --location '${URL}' --output "$zip"
   unzip -q -o -d "$cache" "$zip"
   rm -f "$zip"
   touch "$cache.complete"

--- a/bootstrap/run.cjs
+++ b/bootstrap/run.cjs
@@ -30,8 +30,8 @@ zip="$RUNNER_TEMP/deno-${DENO_VERSION}.zip"
 echo $(uname -sm) $RUNNER_OS
 
 case $RUNNER_OS-$(uname -m); in
-Windows-x86_64) target="x86_64-pc-windows-msvc";;
-Darwin-x86_64)  target="x86_64-apple-darwin";;
+Windows-x86_64) target="x86_64-pc-windows-msvc" ;;
+Darwin-x86_64)  target="x86_64-apple-darwin" ;;
 Darwin-arm64)   target="aarch64-apple-darwin" ;;
 Linux-aarch64)  target="aarch64-unknown-linux-gnu" ;;
 Linux-x86_64)   target="x86_64-unknown-linux-gnu" ;;

--- a/bootstrap/run.cjs
+++ b/bootstrap/run.cjs
@@ -18,51 +18,24 @@ if (!process.env.RUNNER_TOOL_CACHE || !process.env.RUNNER_TEMP) {
 }
 
 module.exports = (file) => {
-  const [command, ...args] = process.platform === "win32"
-    ? [
-      "powershell",
-      "-Command",
-      `
-$ErrorActionPreference = "Stop"
-
-$cache = "$env:RUNNER_TOOL_CACHE\\deno-action\\${DENO_VERSION}\\${process.arch}"
-$null = New-Item -ItemType Directory -Force -Path $cache
-$zip = "$env:RUNNER_TEMP\\deno-${DENO_VERSION}.zip"
-
-$target = "x86_64-pc-windows-msvc"
-$url = "https://github.com/denoland/deno/releases/download/v1.44.4/deno-$target.zip"
-
-if (-not (Test-Path -Path "$cache.complete")) {
-  echo "Downloading Deno..."
-  curl.exe --silent -L $url -o $zip
-  tar.exe -xf $zip -C $cache
-  Remove-Item -Force $zip
-  $null = New-Item -ItemType File -Force -Path "$cache.complete"
-}
-
-$env:DENO_DIR = "$env:RUNNER_TEMP\\.deno"
-
-& "$cache\\deno.exe" run --quiet --no-prompt --allow-all '${file}'
-exit $LastExitCode
-    `,
-    ]
-    : [
-      "sh",
-      "-c",
-      `
+  const child = spawnSync("bash", [
+    "-c",
+    `
 set -e
 
 cache="$RUNNER_TOOL_CACHE/deno-action/${DENO_VERSION}/${process.arch}"
 mkdir -p "$cache"
 zip="$RUNNER_TEMP/deno-${DENO_VERSION}.zip"
 
-case $(uname -sm) in
-"Darwin x86_64")  target="x86_64-apple-darwin";;
-"Darwin arm64")   target="aarch64-apple-darwin" ;;
-"Linux aarch64")  target="aarch64-unknown-linux-gnu" ;;
-"Linux x86_64")   target="x86_64-unknown-linux-gnu" ;;
+case $RUNNER_OS-$(uname -m); in
+Windows-x86_64) target="x86_64-pc-windows-msvc";;
+Darwin-x86_64)  target="x86_64-apple-darwin";;
+Darwin-arm64)   target="aarch64-apple-darwin" ;;
+Linux-aarch64)  target="aarch64-unknown-linux-gnu" ;;
+Linux-x86_64)   target="x86_64-unknown-linux-gnu" ;;
 *) echo "Unsupported os/architecture"; exit 1 ;;
 esac
+
 url="https://github.com/denoland/deno/releases/download/${DENO_VERSION}/deno-\${target}.zip"
 
 if [ ! -f "$cache.complete" ]; then
@@ -78,9 +51,7 @@ export DENO_DIR="$RUNNER_TEMP/.deno"
 chmod +x "$cache/deno"
 exec "$cache/deno" run --quiet --no-prompt --allow-all '${file}'
     `,
-    ];
-
-  const child = spawnSync(command, args, { stdio: "inherit" });
+  ], { stdio: "inherit" });
   if (child.error) throw child.error;
   process.exitCode = child.status;
 };

--- a/bootstrap/run.cjs
+++ b/bootstrap/run.cjs
@@ -21,11 +21,13 @@ module.exports = (file) => {
   const child = spawnSync("bash", [
     "-c",
     `
-set -e
+set -ex
 
 cache="$RUNNER_TOOL_CACHE/deno-action/${DENO_VERSION}/${process.arch}"
 mkdir -p "$cache"
 zip="$RUNNER_TEMP/deno-${DENO_VERSION}.zip"
+
+echo $(uname -sm) $RUNNER_OS
 
 case $RUNNER_OS-$(uname -m); in
 Windows-x86_64) target="x86_64-pc-windows-msvc";;

--- a/bootstrap/run.cjs
+++ b/bootstrap/run.cjs
@@ -37,7 +37,7 @@ module.exports = (file) => {
   const child = spawnSync("bash", [
     "-c",
     `
-set -ex
+set -e
 
 cache="$RUNNER_TOOL_CACHE/deno-action/${DENO_VERSION}/${process.arch}"
 mkdir -p "$cache"


### PR DESCRIPTION
As long as they don't break semver (which I don't think they'll do), and as long as we don't use unstable features, this shouldn't break anything.

Moved to top-level await to do this, and therefore depends on esm and node20, but I think that's probably fine.