### PR TITLE
Only run the example in this repo

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'tombl/deno-action'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
I avoid using GitHub's hosted runners in private repos, but keep
accidentally using them when I use this template. This avoids that.
